### PR TITLE
Add simple Python curses title screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Game Title Screen
+
+This repository contains a simple Python script that displays a title screen for a game using the built-in `curses` module.
+
+## Requirements
+
+- Python 3.x (with `curses` support)
+
+## Usage
+
+Run the script from your terminal:
+
+```bash
+python title_screen.py
+```
+
+Press any key to proceed from the title screen.

--- a/title_screen.py
+++ b/title_screen.py
@@ -1,0 +1,30 @@
+import curses
+import time
+
+
+def main(stdscr):
+    curses.curs_set(0)
+    stdscr.nodelay(False)
+    stdscr.clear()
+    h, w = stdscr.getmaxyx()
+
+    title = "MY AWESOME GAME"
+    instruction = "Press any key to start..."
+
+    x_title = (w // 2) - (len(title) // 2)
+    x_instr = (w // 2) - (len(instruction) // 2)
+
+    stdscr.addstr(h // 2, x_title, title, curses.A_BOLD)
+    stdscr.addstr(h // 2 + 2, x_instr, instruction)
+    stdscr.refresh()
+
+    stdscr.getch()
+
+    stdscr.clear()
+    stdscr.addstr(h // 2, (w // 2) - len("Game Starting...") // 2, "Game Starting...")
+    stdscr.refresh()
+    time.sleep(1)
+
+
+if __name__ == "__main__":
+    curses.wrapper(main)


### PR DESCRIPTION
## Summary
- add a Python script that shows a terminal title screen using `curses`
- document how to run the script in a README

## Testing
- `python -m py_compile title_screen.py`


------
https://chatgpt.com/codex/tasks/task_e_685f21ece7388327a23a12da527ea50d