### PR TITLE
Update title screen text and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ python title_screen.py
 ```
 
 Press any key to proceed from the title screen.
+
+## Building an executable
+
+If you want to create a standalone executable (for example on Windows), install
+`pyinstaller` and run the provided build script:
+
+```bash
+pip install pyinstaller
+./build_exe.sh
+```
+
+The resulting executable will be placed in the `dist` directory.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Game Title Screen
+
+This repository contains a simple Python script that displays a title screen using the built-in `curses` module.
+The title now reads **"This is an Exercise"** and shows options "Start", "Options", and "Quit" at the bottom of the screen.
+
+## Requirements
+
+- Python 3.x (with `curses` support)
+
+## Usage
+
+Run the script from your terminal:
+
+```bash
+python title_screen.py
+```
+
+Press any key to proceed from the title screen.

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Build a standalone executable using PyInstaller
+pyinstaller --onefile title_screen.py

--- a/title_screen.py
+++ b/title_screen.py
@@ -1,0 +1,33 @@
+import curses
+import time
+
+
+def main(stdscr):
+    curses.curs_set(0)
+    stdscr.nodelay(False)
+    stdscr.clear()
+    h, w = stdscr.getmaxyx()
+
+    title = "This is an Exercise"
+    instruction = "Press any key to continue..."
+    options = "Start   Options   Quit"
+
+    x_title = (w // 2) - (len(title) // 2)
+    x_instr = (w // 2) - (len(instruction) // 2)
+    x_opts = (w // 2) - (len(options) // 2)
+
+    stdscr.addstr(h // 2, x_title, title, curses.A_BOLD)
+    stdscr.addstr(h // 2 + 2, x_instr, instruction)
+    stdscr.addstr(h - 2, x_opts, options)
+    stdscr.refresh()
+
+    stdscr.getch()
+
+    stdscr.clear()
+    stdscr.addstr(h // 2, (w // 2) - len("Game Starting...") // 2, "Game Starting...")
+    stdscr.refresh()
+    time.sleep(1)
+
+
+if __name__ == "__main__":
+    curses.wrapper(main)


### PR DESCRIPTION
## Summary
- update the title text
- display Start, Options and Quit at the bottom
- document new text in README

## Testing
- `python -m py_compile title_screen.py`


------
https://chatgpt.com/codex/tasks/task_e_685f21ece7388327a23a12da527ea50d